### PR TITLE
Removed server URL to booth template

### DIFF
--- a/decide/booth/templates/booth/booth.html
+++ b/decide/booth/templates/booth/booth.html
@@ -90,7 +90,7 @@
                 voter: user.id,
                 token: token
             }
-            postData("{{store_url}}" + "/store/", data)
+            postData("/store/", data)
               .then(data => {
                 alert("{% trans "Conglatulations. Your vote has been sent" %}")
                 console.log(v);
@@ -103,7 +103,7 @@
 
         function decideLogout() {
             var data = { token: token };
-            postData("{{auth_url}}" + "/authentication/logout/", data);
+            postData("/authentication/logout/", data);
 
             token = null;
             user = null;
@@ -113,7 +113,7 @@
 
         function decideUser() {
             var data = { token: token };
-            postData("{{auth_url}}" + "/authentication/getuser/", data)
+            postData("/authentication/getuser/", data)
               .then(data => {
                 user = data;
                 panel('voting');
@@ -127,7 +127,7 @@
                 username: document.querySelector("#username").value,
                 password: document.querySelector("#password").value,
             };
-            postData("{{auth_url}}" + "/authentication/login/", data)
+            postData("/authentication/login/", data)
               .then(data => {
                 document.cookie = 'decide='+data.token+';';
                 token = data.token;


### PR DESCRIPTION
This commit removes the server URL that was included in the Javascript of the booth template because it forced the web browser to have access to the URLs of the bridge in a Docker-based deployment